### PR TITLE
[REFACTOR] 공통 응답 형식 변경 - #22

### DIFF
--- a/src/main/java/com/sopt/agoda/common/converter/SaleTypeConverter.java
+++ b/src/main/java/com/sopt/agoda/common/converter/SaleTypeConverter.java
@@ -8,6 +8,6 @@ public class SaleTypeConverter implements Converter<String, SaleType> {
 
     @Override
     public SaleType convert(@NonNull final String saleType) {
-        return SaleType.fromString(saleType);
+        return SaleType.create(saleType.toUpperCase());
     }
 }

--- a/src/main/java/com/sopt/agoda/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/agoda/common/handler/GlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -52,7 +51,7 @@ public class GlobalExceptionHandler {
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining("\n")); // 메시지를 줄바꿈으로 연결
 
-        return ApiResponseUtil.failure(HttpStatus.BAD_REQUEST, errorMessage);
+        return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_REQUEST_BODY_VALID, errorMessage);
     }
 
     /**
@@ -67,7 +66,7 @@ public class GlobalExceptionHandler {
                 .map(MessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining("\n"));
 
-        return ApiResponseUtil.failure(HttpStatus.BAD_REQUEST, errorMessage);
+        return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_REQUEST_PARAM_MODELATTRI, errorMessage);
     }
 
     /**
@@ -77,7 +76,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<BaseResponse<?>> handleMissingServletRequestParameterException(final MissingServletRequestParameterException e) {
         final String errorMessage = "누락된 파라미터 : " + e.getParameterName();
-        return ApiResponseUtil.failure(HttpStatus.BAD_REQUEST, errorMessage);
+        return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_MISSING_PARAM, errorMessage);
     }
 
     /**
@@ -87,7 +86,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<BaseResponse<?>> handleMethodArgumentTypeMismatchException(final MethodArgumentTypeMismatchException e) {
         final String errorMessage = "잘못된 인자값 : " + e.getParameter().getParameterName();
-        return ApiResponseUtil.failure(HttpStatus.BAD_REQUEST, errorMessage);
+        return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_METHOD_ARGUMENT_TYPE, errorMessage);
     }
 
     /**
@@ -102,9 +101,9 @@ public class GlobalExceptionHandler {
                     .map(ref -> String.format("잘못된 필드 값 : '%s'", ref.getFieldName()))
                     .collect(Collectors.joining("\n"));
 
-            return ApiResponseUtil.failure(HttpStatus.BAD_REQUEST, errorMessage);
+            return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_NOT_READABLE, errorMessage);
         } else { //그 외의 경우들
-            return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_JSON);
+            return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_NOT_READABLE);
         }
     }
 
@@ -141,7 +140,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<BaseResponse<?>> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
-        return ApiResponseUtil.failure(FailMessage.BAD_REQUEST_HTTP_METHOD);
+        return ApiResponseUtil.failure(FailMessage.METHOD_NOT_ALLOWED);
     }
 
     /**
@@ -156,7 +155,7 @@ public class GlobalExceptionHandler {
             String constraintName = constraintViolationException.getConstraintViolations().toString();
             String errorMessage = String.format("제약 조건 '%s' 위반이 발생했습니다.", constraintName);
             log.info(errorMessage);
-            return ApiResponseUtil.failure(HttpStatus.CONFLICT, errorMessage);
+            return ApiResponseUtil.failure(FailMessage.INTEGRITY_CONFLICT, errorMessage);
         } else {
             log.info(e.getMessage());
             return ApiResponseUtil.failure(FailMessage.INTEGRITY_CONFLICT);
@@ -169,7 +168,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<?>> handleAllExceptions(final Exception e) {
         log.info(e.getMessage());
-        System.out.println(e);
        return ApiResponseUtil.failure(FailMessage.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/sopt/agoda/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/agoda/common/handler/GlobalExceptionHandler.java
@@ -167,7 +167,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<?>> handleAllExceptions(final Exception e) {
-        log.info(e.getMessage());
+        log.error(e.getMessage());
        return ApiResponseUtil.failure(FailMessage.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/sopt/agoda/common/response/ApiResponseUtil.java
+++ b/src/main/java/com/sopt/agoda/common/response/ApiResponseUtil.java
@@ -1,30 +1,30 @@
 package com.sopt.agoda.common.response;
 
+import com.amazonaws.Response;
 import com.sopt.agoda.common.response.message.FailMessage;
 import com.sopt.agoda.common.response.message.SuccessMessage;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 
-public interface ApiResponseUtil {
-    static ResponseEntity<BaseResponse<?>> success(final SuccessMessage successMessage) {
-        return ResponseEntity.status(successMessage.getHttpStatus())
+public class ApiResponseUtil {
+    public static ResponseEntity<BaseResponse<?>> success(final SuccessMessage successMessage) {
+        return org.springframework.http.ResponseEntity.status(successMessage.getHttpStatus())
                 .body(BaseResponse.of(successMessage));
     }
 
-    static <T> ResponseEntity<BaseResponse<?>> success(final SuccessMessage successMessage, final T data) {
+    public static <T> ResponseEntity<BaseResponse<?>> success(final SuccessMessage successMessage, final T data) {
         return ResponseEntity.status(successMessage.getHttpStatus())
                 .body(BaseResponse.of(successMessage, data));
     }
 
-    static ResponseEntity<BaseResponse<?>> failure(final FailMessage failMessage) {
+    public static ResponseEntity<BaseResponse<?>> failure(final FailMessage failMessage) {
         return ResponseEntity.status(failMessage.getHttpStatus())
                 .body(BaseResponse.of(failMessage));
     }
 
-    static ResponseEntity<BaseResponse<?>> failure(final HttpStatus httpStatus, final String message) {
+    public static ResponseEntity<BaseResponse<?>> failure(final FailMessage failMessage, final String message) {
         return ResponseEntity
-                .status(httpStatus)
-                .body(BaseResponse.of(httpStatus, message));
+                .status(failMessage.getHttpStatus())
+                .body(BaseResponse.of(failMessage.getCode(), message));
     }
 }

--- a/src/main/java/com/sopt/agoda/common/response/BaseResponse.java
+++ b/src/main/java/com/sopt/agoda/common/response/BaseResponse.java
@@ -7,27 +7,27 @@ import org.springframework.http.HttpStatus;
 
 
 public class BaseResponse<T> {
-    private final int status;
+    private final int code;
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private final T data;
 
-    private BaseResponse(int status, String message, T data) {
-        this.status = status;
+    private BaseResponse(final int status, final String message, final T data) {
+        this.code = status;
         this.message = message;
         this.data = data;
     }
 
     public static BaseResponse<?> of(SuccessMessage successMessage) {
         return builder()
-                .status(successMessage.getHttpStatus().value())
+                .status(successMessage.getCode())
                 .message(successMessage.getMessage())
                 .build();
     }
 
     public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
         return builder()
-                .status(successMessage.getHttpStatus().value())
+                .status(successMessage.getCode())
                 .message(successMessage.getMessage())
                 .data(data)
                 .build();
@@ -35,40 +35,40 @@ public class BaseResponse<T> {
 
     public static BaseResponse<?> of(FailMessage failMessage) {
         return builder()
-                .status(failMessage.getHttpStatus().value())
+                .status(failMessage.getCode())
                 .message(failMessage.getMessage())
                 .build();
     }
 
-    public static BaseResponse<?> of(HttpStatus httpStatus, String message) {
+    public static BaseResponse<?> of(final int code, final String message) {
         return builder()
-                .status(httpStatus.value())
+                .status(code)
                 .message(message)
                 .build();
     }
 
     public static class Builder<T> {
-        private int status;
+        private int code;
         private String message;
         private T data;
 
-        public Builder<T> status(int status) {
-            this.status = status;
+        public Builder<T> status(final int status) {
+            this.code = status;
             return this;
         }
 
-        public Builder<T> message(String message) {
+        public Builder<T> message(final String message) {
             this.message = message;
             return this;
         }
 
-        public Builder<T> data(T data) {
+        public Builder<T> data(final T data) {
             this.data = data;
             return this;
         }
 
         public BaseResponse<T> build() {
-            return new BaseResponse<>(status, message, data);
+            return new BaseResponse<>(code, message, data);
         }
     }
 
@@ -76,8 +76,8 @@ public class BaseResponse<T> {
         return new Builder<>();
     }
 
-    public int getStatus() {
-        return status;
+    public int getCode() {
+        return code;
     }
 
     public String getMessage() {

--- a/src/main/java/com/sopt/agoda/common/response/BaseResponse.java
+++ b/src/main/java/com/sopt/agoda/common/response/BaseResponse.java
@@ -1,9 +1,8 @@
 package com.sopt.agoda.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sopt.agoda.common.response.message.FailMessage;
+import com.sopt.agoda.common.response.message.ApiMessage;
 import com.sopt.agoda.common.response.message.SuccessMessage;
-import org.springframework.http.HttpStatus;
 
 
 public class BaseResponse<T> {
@@ -18,61 +17,54 @@ public class BaseResponse<T> {
         this.data = data;
     }
 
-    public static BaseResponse<?> of(SuccessMessage successMessage) {
+    public static BaseResponse<?> of(final ApiMessage apiMessage) {
         return builder()
-                .status(successMessage.getCode())
-                .message(successMessage.getMessage())
+                .code(apiMessage.getCode())
+                .message(apiMessage.getMessage())
                 .build();
     }
 
     public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
         return builder()
-                .status(successMessage.getCode())
+                .code(successMessage.getCode())
                 .message(successMessage.getMessage())
                 .data(data)
                 .build();
     }
 
-    public static BaseResponse<?> of(FailMessage failMessage) {
-        return builder()
-                .status(failMessage.getCode())
-                .message(failMessage.getMessage())
-                .build();
-    }
-
     public static BaseResponse<?> of(final int code, final String message) {
         return builder()
-                .status(code)
+                .code(code)
                 .message(message)
                 .build();
     }
 
-    public static class Builder<T> {
+    private static class Builder<T> {
         private int code;
         private String message;
         private T data;
 
-        public Builder<T> status(final int status) {
-            this.code = status;
+        private Builder<T> code(final int code) {
+            this.code = code;
             return this;
         }
 
-        public Builder<T> message(final String message) {
+        private Builder<T> message(final String message) {
             this.message = message;
             return this;
         }
 
-        public Builder<T> data(final T data) {
+        private Builder<T> data(final T data) {
             this.data = data;
             return this;
         }
 
-        public BaseResponse<T> build() {
+        private BaseResponse<T> build() {
             return new BaseResponse<>(code, message, data);
         }
     }
 
-    public static <T> Builder<T> builder() {
+    private static <T> Builder<T> builder() {
         return new Builder<>();
     }
 

--- a/src/main/java/com/sopt/agoda/common/response/message/ApiMessage.java
+++ b/src/main/java/com/sopt/agoda/common/response/message/ApiMessage.java
@@ -4,5 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public interface ApiMessage {
     HttpStatus getHttpStatus();
+    int getCode();
     String getMessage();
 }

--- a/src/main/java/com/sopt/agoda/common/response/message/FailMessage.java
+++ b/src/main/java/com/sopt/agoda/common/response/message/FailMessage.java
@@ -12,13 +12,7 @@ public enum FailMessage implements ApiMessage{
     BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST, 40003, "필수 param이 없습니다."),
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40004, "메서드 인자타입이 잘못되었습니다."),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40005, "json 오류 혹은 reqeust body 필드 오류 입니다."),
-
-
-
-
-    BAD_REQUEST_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, 40001, "유효하지 않은 요청 파라미터 값입니다."),
-    BAD_REQUEST_JSON(HttpStatus.BAD_REQUEST, 40002, "잘못된 JSON 형식입니다."),
-    BAD_REQUEST_SALETYPE_VALUE(HttpStatus.BAD_REQUEST,40003, "잘못된 SaleType입니다."),
+    BAD_REQUEST_SALETYPE_VALUE(HttpStatus.BAD_REQUEST,40006, "잘못된 SaleType입니다."),
 
     /**
      * 401 Unauthorized
@@ -34,19 +28,19 @@ public enum FailMessage implements ApiMessage{
      * 404 Not Found
      */
     NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND,40400, "대상을 찾을 수 없습니다."),
-    NOT_FOUND_API(HttpStatus.NOT_FOUND, 40401, "잘못된 API입니다.."),
+    NOT_FOUND_API(HttpStatus.NOT_FOUND, 40401, "잘못된 API입니다."),
     NOT_FOUND_POPULAR_CITIES(HttpStatus.NOT_FOUND, 40402, "인기 도시를 찾을 수 없습니다."),
     NOT_FOUND_BEST_COUNTRY(HttpStatus.NOT_FOUND, 40403, "베스트 여행지를 찾을 수 없습니다."),
     NOT_FOUND_SEARCH_CITIES(HttpStatus.NOT_FOUND, 40404, "검색 도시 리스트를 찾을 수 없습니다."),
-    NOT_FOUND_HOTELS(HttpStatus.NOT_FOUND, 40405, "호텔 리스트를 찾을 수 없습니다. "),
-    NOT_FOUND_HOTEL(HttpStatus.NOT_FOUND, 40406, "호텔 정보를 찾을 수 없습니다. "),
-    NOT_FOUND_HOTEL_IMAGES(HttpStatus.NOT_FOUND, 40407, "호텔 이미지를 찾을 수 없습니다. "),
-    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, 40408, "방 정보를 찾을 수 없습니다. "),
-    NOT_FOUND_ROOM_IMAGES(HttpStatus.NOT_FOUND, 40409, "방 이미지를 찾을 수 없습니다. "),
+    NOT_FOUND_HOTELS(HttpStatus.NOT_FOUND, 40405, "호텔 리스트를 찾을 수 없습니다."),
+    NOT_FOUND_HOTEL(HttpStatus.NOT_FOUND, 40406, "호텔 정보를 찾을 수 없습니다."),
+    NOT_FOUND_HOTEL_IMAGES(HttpStatus.NOT_FOUND, 40407, "호텔 이미지를 찾을 수 없습니다."),
+    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, 40408, "방 정보를 찾을 수 없습니다."),
+    NOT_FOUND_ROOM_IMAGES(HttpStatus.NOT_FOUND, 40409, "방 이미지를 찾을 수 없습니다."),
     /**
      * 405 Method Not Allowed
      */
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40400, "잘못된 HTTP method 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "잘못된 HTTP method 요청입니다."),
 
     /**
      * 409 Conflict

--- a/src/main/java/com/sopt/agoda/common/response/message/FailMessage.java
+++ b/src/main/java/com/sopt/agoda/common/response/message/FailMessage.java
@@ -1,67 +1,80 @@
 package com.sopt.agoda.common.response.message;
 
-import com.sopt.agoda.hotel.domain.HotelImage;
 import org.springframework.http.HttpStatus;
 
 public enum FailMessage implements ApiMessage{
     /**
      * 400 Bad Request
      */
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    BAD_REQUEST_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 요청 파라미터 값입니다."),
-    BAD_REQUEST_JSON(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
-    BAD_REQUEST_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 http method입니다."),
-    BAD_REQUEST_SALETYPE_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, "잘못된 인자값 : SaleType"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,40000, "잘못된 요청입니다."),
+    BAD_REQUEST_REQUEST_BODY_VALID(HttpStatus.BAD_REQUEST, 40001, "request body 검증 실패입니다."),
+    BAD_REQUEST_REQUEST_PARAM_MODELATTRI(HttpStatus.BAD_REQUEST, 40002, "request param 혹은 modelattribute 검증 실패입니다."),
+    BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST, 40003, "필수 param이 없습니다."),
+    BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40004, "메서드 인자타입이 잘못되었습니다."),
+    BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40005, "json 오류 혹은 reqeust body 필드 오류 입니다."),
+
+
+
+
+    BAD_REQUEST_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, 40001, "유효하지 않은 요청 파라미터 값입니다."),
+    BAD_REQUEST_JSON(HttpStatus.BAD_REQUEST, 40002, "잘못된 JSON 형식입니다."),
+    BAD_REQUEST_SALETYPE_VALUE(HttpStatus.BAD_REQUEST,40003, "잘못된 SaleType입니다."),
 
     /**
      * 401 Unauthorized
      */
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 인증 권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "리소스 접근 인증 권한이 없습니다."),
 
     /**
      * 403 Forbidden
      */
-    FORBIDDEN(HttpStatus.FORBIDDEN, "리소스 접근 인가 권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "리소스 접근 인가 권한이 없습니다."),
 
     /**
      * 404 Not Found
      */
-    NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND, "대상을 찾을 수 없습니다."),
-    NOT_FOUND_API(HttpStatus.NOT_FOUND, "잘못된 API입니다.."),
-    NOT_FOUND_POPULAR_CITIES(HttpStatus.NOT_FOUND, "인기 도시를 찾을 수 없습니다."),
-    NOT_FOUND_BEST_COUNTRY(HttpStatus.NOT_FOUND, "베스트 여행지를 찾을 수 없습니다."),
-    NOT_FOUND_SEARCH_CITIES(HttpStatus.NOT_FOUND, "검색 도시 리스트를 찾을 수 없습니다."),
-    NOT_FOUND_HOTELS(HttpStatus.NOT_FOUND, "호텔 리스트를 찾을 수 없습니다. "),
-    NOT_FOUND_HOTEL(HttpStatus.NOT_FOUND, "호텔 정보를 찾을 수 없습니다. "),
-    NOT_FOUND_HOTEL_IMAGES(HttpStatus.NOT_FOUND, "호텔 이미지를 찾을 수 없습니다. "),
-    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, "방 정보를 찾을 수 없습니다. "),
-    NOT_FOUND_ROOM_IMAGES(HttpStatus.NOT_FOUND, "방 이미지를 찾을 수 없습니다. "),
+    NOT_FOUND_ENTITY(HttpStatus.NOT_FOUND,40400, "대상을 찾을 수 없습니다."),
+    NOT_FOUND_API(HttpStatus.NOT_FOUND, 40401, "잘못된 API입니다.."),
+    NOT_FOUND_POPULAR_CITIES(HttpStatus.NOT_FOUND, 40402, "인기 도시를 찾을 수 없습니다."),
+    NOT_FOUND_BEST_COUNTRY(HttpStatus.NOT_FOUND, 40403, "베스트 여행지를 찾을 수 없습니다."),
+    NOT_FOUND_SEARCH_CITIES(HttpStatus.NOT_FOUND, 40404, "검색 도시 리스트를 찾을 수 없습니다."),
+    NOT_FOUND_HOTELS(HttpStatus.NOT_FOUND, 40405, "호텔 리스트를 찾을 수 없습니다. "),
+    NOT_FOUND_HOTEL(HttpStatus.NOT_FOUND, 40406, "호텔 정보를 찾을 수 없습니다. "),
+    NOT_FOUND_HOTEL_IMAGES(HttpStatus.NOT_FOUND, 40407, "호텔 이미지를 찾을 수 없습니다. "),
+    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, 40408, "방 정보를 찾을 수 없습니다. "),
+    NOT_FOUND_ROOM_IMAGES(HttpStatus.NOT_FOUND, 40409, "방 이미지를 찾을 수 없습니다. "),
     /**
      * 405 Method Not Allowed
      */
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40400, "잘못된 HTTP method 요청입니다."),
 
     /**
      * 409 Conflict
      */
-    CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
-    INTEGRITY_CONFLICT(HttpStatus.CONFLICT, "데이터 무결성 위반입니다."),
+    CONFLICT(HttpStatus.CONFLICT, 40900, "이미 존재하는 리소스입니다."),
+    INTEGRITY_CONFLICT(HttpStatus.CONFLICT, 40901, "데이터 무결성 위반입니다."),
 
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,50000, "서버 내부 오류입니다.");
 
     private final HttpStatus httpStatus;
+    private final int code;
     private final String message;
 
-    private FailMessage(HttpStatus httpStatus, String message) {
+    private FailMessage(final HttpStatus httpStatus, final int code, final String message) {
         this.httpStatus = httpStatus;
+        this.code = code;
         this.message = message;
     }
 
     public HttpStatus getHttpStatus() {
         return httpStatus;
+    }
+
+    public int getCode() {
+        return code;
     }
 
     public String getMessage() {

--- a/src/main/java/com/sopt/agoda/common/response/message/SuccessMessage.java
+++ b/src/main/java/com/sopt/agoda/common/response/message/SuccessMessage.java
@@ -6,23 +6,31 @@ public enum SuccessMessage implements ApiMessage{
     /**
      * 200 OK
      */
-    OK(HttpStatus.OK, "요청이 성공했습니다."),
+    OK(HttpStatus.OK,20000, "요청이 성공했습니다."),
+    OK_HOTEL_LIKE(HttpStatus.OK, 20001, "호텔 좋아요에 성공했습니다."),
+    OK_HOTEL_UNLIKE(HttpStatus.OK, 20002, "호텔 좋아요 취소에 성공했습니다"),
 
     /**
      * 201 Created
      */
-    CREATED(HttpStatus.CREATED, "요청이 성공했습니다.");
+    CREATED(HttpStatus.CREATED,200100, "요청이 성공했습니다.");
 
     private final HttpStatus httpStatus;
+    private final int code;
     private final String message;
 
-    private SuccessMessage(HttpStatus httpStatus, String message) {
+    private SuccessMessage(final HttpStatus httpStatus, final int code, final  String message) {
         this.httpStatus = httpStatus;
+        this.code = code;
         this.message = message;
     }
 
     public HttpStatus getHttpStatus() {
         return httpStatus;
+    }
+
+    public int getCode() {
+        return code;
     }
 
     public String getMessage() {

--- a/src/main/java/com/sopt/agoda/hotel/controller/HotelController.java
+++ b/src/main/java/com/sopt/agoda/hotel/controller/HotelController.java
@@ -17,13 +17,15 @@ import org.springframework.web.bind.annotation.*;
 public class HotelController {
     private final HotelService hotelService;
 
-    public HotelController(HotelService hotelService) { this.hotelService = hotelService; }
+    public HotelController(HotelService hotelService) {
+        this.hotelService = hotelService;
+    }
 
     @GetMapping()
     public ResponseEntity<BaseResponse<?>> getHotelList(
-            @RequestParam(value="saleType", required = true) final SaleType saleType,
-            @RequestParam(value="cityId", required = true) @Min(1) final Long cityId
-            ) {
+            @RequestParam(value = "saleType", required = true) final SaleType saleType,
+            @RequestParam(value = "cityId", required = true) @Min(1) final Long cityId
+    ) {
         final HotelListRes hotels = hotelService.getHotelList(saleType, cityId);
         return ApiResponseUtil.success(SuccessMessage.OK, hotels);
     }
@@ -47,7 +49,11 @@ public class HotelController {
             @RequestParam(value = "isLiked", required = true) final boolean isLiked
     ) {
         hotelService.patchHotelLike(hotelId, isLiked);
-        return ApiResponseUtil.success(SuccessMessage.OK);
+        if (isLiked) {
+            return ApiResponseUtil.success(SuccessMessage.OK_HOTEL_LIKE);
+        } else {
+            return ApiResponseUtil.success(SuccessMessage.OK_HOTEL_UNLIKE
+            );
+        }
     }
-
 }

--- a/src/main/java/com/sopt/agoda/hotel/domain/Hotel.java
+++ b/src/main/java/com/sopt/agoda/hotel/domain/Hotel.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "hotels")

--- a/src/main/java/com/sopt/agoda/hotel/enums/SaleType.java
+++ b/src/main/java/com/sopt/agoda/hotel/enums/SaleType.java
@@ -4,25 +4,15 @@ import com.sopt.agoda.common.exception.AgodaException;
 import com.sopt.agoda.common.response.message.FailMessage;
 
 public enum SaleType {
-    DEFAULT("default"),
-    TIME_LIMIT("timeLimit");
+    DEFAULT,
+    TIME_LIMIT;
 
-    private final String value;
-
-    SaleType(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public static SaleType fromString(String value) {
-        for (SaleType saleType : values()) {
-            if (saleType.getValue().equalsIgnoreCase(value)) {
-                return saleType;
+    public static SaleType create(String requestCategory) {
+        for (SaleType value : SaleType.values()) {
+            if (value.toString().equals(requestCategory)) {
+                return value;
             }
         }
-        throw new AgodaException(FailMessage.BAD_REQUEST_SALETYPE_PARAMETER_VALUE);
+        throw new AgodaException(FailMessage.BAD_REQUEST_SALETYPE_VALUE);
     }
 }

--- a/src/main/java/com/sopt/agoda/hotel/enums/SaleType.java
+++ b/src/main/java/com/sopt/agoda/hotel/enums/SaleType.java
@@ -7,9 +7,9 @@ public enum SaleType {
     DEFAULT,
     TIME_LIMIT;
 
-    public static SaleType create(String requestCategory) {
+    public static SaleType create(final String requestSaleType) {
         for (SaleType value : SaleType.values()) {
-            if (value.toString().equals(requestCategory)) {
+            if (value.toString().equals(requestSaleType)) {
                 return value;
             }
         }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #22 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 공통 응답 형식 변경

클라한테 내려주는 값들을 code와 message만 내려주는 거로 변경하였습니다.
굳이 status까지 response에 내려줄 필요가 없기 떄문입니다(기본 http응답에 있으므로)
code는 명세서와 함께 작성하여 클라에게 전달할 예정입니다.
   
예시 응답은 아래와 같습니다
- 실패 응답
<img width="348" alt="스크린샷 2024-11-22 18 21 53" src="https://github.com/user-attachments/assets/7a903ad9-8702-40d8-967d-db1ecce8face">

- 성공 응답
<img width="512" alt="스크린샷 2024-11-22 18 25 29" src="https://github.com/user-attachments/assets/98ec920f-97f4-4ae0-a224-32393597b4a8">


- ApiMessage로 successMessage와 faildMessage 같이 받을 수 있도록 했습니다.
```java
    public static BaseResponse<?> of(final ApiMessage apiMessage) {
        return builder()
                .code(apiMessage.getCode())
                .message(apiMessage.getMessage())
                .build();
    }
```


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
